### PR TITLE
Clear classes compile cache

### DIFF
--- a/src/Foundation/Console/ClearCompiledCommand.php
+++ b/src/Foundation/Console/ClearCompiledCommand.php
@@ -13,7 +13,7 @@ class ClearCompiledCommand extends ClearCompiledCommandBase
     public function handle()
     {
         if (file_exists($classesPath = $this->laravel->getCachedClassesPath())) {
-            @unlink($servicesPath);
+            @unlink($classesPath);
         }
 
         parent::handle();


### PR DESCRIPTION
Remove the classes compile cache instead of the services cache.
The services cache gets cleared in the parent::handle()